### PR TITLE
Replace sizeThatFits with layoutIfNeeded

### DIFF
--- a/Gallery/Public/Snapshot/SnapshotTestsGenerator.swift
+++ b/Gallery/Public/Snapshot/SnapshotTestsGenerator.swift
@@ -102,7 +102,7 @@ public struct SnapshotTestsGenerator {
                 view.heightAnchor.constraint(equalToConstant: height).isActive = true
             }
 
-            view.sizeToFit()
+            container.layoutIfNeeded()
 
             testCase.verify(view: view)
         }


### PR DESCRIPTION
We're having issues with one test where the snapshots don't respect the specified size constraints, and using `layoutIfNeeded` on the superview fixes it, and also seems to be the correct intention. The rest of our snapshot tests continue to pass after this change.

Let me know what you think 😄 